### PR TITLE
feat: Add file inclusion and exclusion options

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,22 @@ export default defineConfig({
 });
 ```
 
+or with include/exclude options 
+
+```js
+// vite.config.js
+import libCss from 'vite-plugin-libcss';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [
+    // any other plugins
+    libCss({
+      include: 'src/**/*', // Include all entry files
+      exclude: 'src/utils/*', // Exclude entry files in the "utils" directory
+    })
+  ],
+});
+```
+
 Note that this plugin will only work with [library-mode](https://vitejs.dev/guide/build.html#library-mode) and es format build.

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ import type { PluginOption } from 'vite';
 
 type LibCssOptions = {
   include?: string;
-  exclude?: string | string[];
+  exclude?: string;
 }
 
 export default function (option: LibCssOptions): PluginOption

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,8 @@
-import type { ResolvedConfig, PluginOption } from 'vite';
+import type { PluginOption } from 'vite';
 
-export default function (): PluginOption
+type LibCssOptions = {
+  include?: string;
+  exclude?: string | string[];
+}
+
+export default function (option: LibCssOptions): PluginOption

--- a/index.js
+++ b/index.js
@@ -1,22 +1,23 @@
 const fs = require('fs');
 const { resolve } = require('path');
+const minimatch = require('minimatch');
 
 let viteConfig;
 
-module.exports = function () {
+module.exports = function (options = {}) {
   return {
     name: 'lib-css',
     apply: 'build',
     enforce: 'post',
 
-    configResolved (resolvedConfig) {
+    configResolved(resolvedConfig) {
       viteConfig = resolvedConfig;
     },
 
-    writeBundle (option, bundle) {
+    writeBundle(option, bundle) {
       if (!viteConfig.build || !viteConfig.build.lib) {
         // only for lib build
-        console.warn('vite-plugin-libcss only works in lib mode.')
+        console.warn('vite-plugin-libcss only works in lib mode.');
         return;
       }
       if (option.format !== 'es') {
@@ -33,6 +34,15 @@ module.exports = function () {
           // only for entry
           continue;
         }
+        if (options.include && !minimatch(file, options.include)) {
+          // check if the file matches the include pattern
+          continue;
+        }
+        if (options.exclude && minimatch(file, options.exclude)) {
+          // check if the file matches the exclude pattern
+          continue;
+        }
+        console.log(file);
         const outDir = viteConfig.build.outDir || 'dist';
         const filePath = resolve(viteConfig.root, outDir, file);
         const data = fs.readFileSync(filePath, {

--- a/index.js
+++ b/index.js
@@ -42,7 +42,6 @@ module.exports = function (options = {}) {
           // check if the file matches the exclude pattern
           continue;
         }
-        console.log(file);
         const outDir = viteConfig.build.outDir || 'dist';
         const filePath = resolve(viteConfig.root, outDir, file);
         const data = fs.readFileSync(filePath, {

--- a/package.json
+++ b/package.json
@@ -22,10 +22,12 @@
     "css"
   ],
   "devDependencies": {
-    "minimatch": "^9.0.1",
     "vite": "2.7.5"
   },
   "peerDependencies": {
     "vite": "*"
+  },
+  "dependencies": {
+    "minimatch": "^9.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "css"
   ],
   "devDependencies": {
+    "minimatch": "^9.0.1",
     "vite": "2.7.5"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,21 +4,23 @@ specifiers:
   minimatch: ^9.0.1
   vite: 2.7.5
 
-devDependencies:
+dependencies:
   minimatch: 9.0.1
+
+devDependencies:
   vite: 2.7.5
 
 packages:
 
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-    dev: true
+    dev: false
 
   /brace-expansion/2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
     dependencies:
       balanced-match: 1.0.2
-    dev: true
+    dev: false
 
   /esbuild-android-arm64/0.13.15:
     resolution: {integrity: sha512-m602nft/XXeO8YQPUDVoHfjyRVPdPgjyyXOxZ44MK/agewFFkPa8tUo6lAzSWh5Ui5PB4KR9UIFTSBKh/RrCmg==}
@@ -210,7 +212,7 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.1
-    dev: true
+    dev: false
 
   /nanoid/3.1.30:
     resolution: {integrity: sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,12 +1,24 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
+  minimatch: ^9.0.1
   vite: 2.7.5
 
 devDependencies:
+  minimatch: 9.0.1
   vite: 2.7.5
 
 packages:
+
+  /balanced-match/1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    dev: true
+
+  /brace-expansion/2.0.1:
+    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+    dependencies:
+      balanced-match: 1.0.2
+    dev: true
 
   /esbuild-android-arm64/0.13.15:
     resolution: {integrity: sha512-m602nft/XXeO8YQPUDVoHfjyRVPdPgjyyXOxZ44MK/agewFFkPa8tUo6lAzSWh5Ui5PB4KR9UIFTSBKh/RrCmg==}
@@ -191,6 +203,13 @@ packages:
     resolution: {integrity: sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==}
     dependencies:
       has: 1.0.3
+    dev: true
+
+  /minimatch/9.0.1:
+    resolution: {integrity: sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
     dev: true
 
   /nanoid/3.1.30:


### PR DESCRIPTION
This commit adds the ability to include or exclude specific files when using the lib-css plugin. The plugin now accepts an optional options parameter, which can contain include and exclude patterns. Files that match the include pattern will be processed by the plugin, while files that match the exclude pattern will be skipped.

This enhancement provides more flexibility and control over which files are affected by the plugin's functionality.