### PR TITLE
fix make plugin parameter optional for TS users

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,4 +5,4 @@ type LibCssOptions = {
   exclude?: string;
 }
 
-export default function (option: LibCssOptions): PluginOption
+export default function (option?: LibCssOptions): PluginOption


### PR DESCRIPTION
Developing in TS, it seemed to be required the 'option' argument. After looking at the code, I passed an empty object as it would not break. Though this is a "nice to have" so interfaces do not differ as from the documentation.

This is my ever first contribution to open-source. And, even though is just a small change, let me know if the PR should have been done in another way. :)