### PR TITLE
Handle nested directories within dist folder

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,10 @@ module.exports = function (options = {}) {
         const data = fs.readFileSync(filePath, {
           encoding: 'utf8',
         });
-        fs.writeFileSync(filePath, `import './${cssFile}';\n${data}`);
+
+        const filePathDepth = file.split('/').length - 1;
+        const relativePath = Array(filePathDepth).fill('../').join('');
+        fs.writeFileSync(filePath, `import './${relativePath}${cssFile}';\n${data}`);
       }
     },
   };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite-plugin-libcss",
   "description": "This plugin will inject css into bundled js file using `import` statement.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "index.js",
   "types": "index.d.ts",
   "author": "wxsms@foxmail.com",


### PR DESCRIPTION
# Problem
The current version of the library assumes that the ES module file is at the root (/dist) folder and injects the CSS import statement. This import fails to work when vite build generates ES modules within nested directories.

For e.g. if the ES module is outputted to `dist/js/ ` the current import fails.

This commit adds the CSS import statement correctly with respect to the depth of the ES module within dist folder.

# Changes
1. Correctly setup the path for the import statement of the ES module where it is being imported.